### PR TITLE
Hot reloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ cd my-app
 npm run start
 ```
 
-
 It will create a directory called `my-app` inside the current folder.<br>
 Inside that directory, it will generate the initial project structure and install Proton Native dependencies:
 
@@ -38,6 +37,15 @@ my-app
 ├── package.json
 ├── index.js
 └── .babelrc
+```
+
+## Running
+
+```sh
+# run your app
+npm run start
+# run your app with hot-reloading
+npm run dev
 ```
 
 ## Packaging

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Create Proton Native App
 
-Create [Proton Native](https://proton-native.js.org/#/) apps with no build configuration. Works on Linux, MacOS and Windows. 
+Create [Proton Native](https://proton-native.js.org/#/) apps with no build configuration. Works on Linux, macOS and Windows.
 
 ## Requirements
 
@@ -16,7 +16,6 @@ Install these libraries:
 - build-essential
 
 
-
 ## Usage
 
 ```sh
@@ -24,14 +23,10 @@ Install these libraries:
 npm install -g create-proton-app
 # create your proton native app
 create-proton-app my-app
-# got to your project directory and have fun!
+# go to your project directory and have fun!
 cd my-app
 npm run start
 ```
-
-
-
-
 
 
 It will create a directory called `my-app` inside the current folder.<br>
@@ -47,7 +42,7 @@ my-app
 
 ## Packaging
 
-We use `electron-builder` to handle the packaging for your application. Produces bundles for Linux(appImages, snaps, deb, rpm, ...) and MacOs. Windows support is unstable.
+We use `electron-builder` to handle the packaging for your application. Produces bundles for Linux (AppImages, Snaps, deb, rpm, ...) and macOS. Windows support is unstable.
 
 
 ```sh
@@ -56,7 +51,7 @@ npm run build
 # bundle it
 npm run dist
 ```
-Only a minimal build/packaging config is provided, as your application grows you should take a look to the  [documentation](https://www.electron.build/).
+Only a minimal build/packaging config is provided, as your application grows you should take a look at the [documentation](https://www.electron.build/).
 
 ## Contributing
 

--- a/src/createApp.js
+++ b/src/createApp.js
@@ -147,11 +147,17 @@ const printSuccessMessage = (rootPath, projectName) => {
   console.log(ansiColors.green, 'npm run start');
   console.log(ansiColors.reset, 'Will run your application.');
   console.log();
-  console.log(ansiColors.green, 'npm run build');
-  console.log(ansiColors.reset, 'Bundles and transpiles your source files.');
+  console.log(ansiColors.green, 'npm run dev');
+  console.log(ansiColors.reset, 'Will run your application with hot-reloading.');
   console.log();
-  console.log('Go to your project folder and run your application typing:')
-  console.log(ansiColors.green, 'cd', ansiColors.reset,`${projectName}`);
+  console.log(ansiColors.green, 'npm run build');
+  console.log(ansiColors.reset, 'Transpiles and bundles your source files.');
+  console.log();
+  console.log(ansiColors.green, 'npm run dist');
+  console.log(ansiColors.reset, 'Creates an archive containing the bundle.');
+  console.log();
+  console.log('Go to your project folder and run your application by typing:')
+  console.log(ansiColors.green, 'cd ' + ansiColors.reset + `${projectName}`);
   console.log(ansiColors.green,'npm run start');
   console.log(ansiColors.reset);
   console.log();

--- a/src/createApp.js
+++ b/src/createApp.js
@@ -44,6 +44,7 @@ const createApp = function(projectDir) {
     scripts: {
       "start": "node_modules/.bin/babel-node index.js",
       "build": "node_modules/.bin/babel index.js -d bin/",
+      "dev": "proton-hot-cli index.js",
       "pack": "electron-builder --dir",
       "dist": "electron-builder"
     },
@@ -52,6 +53,7 @@ const createApp = function(projectDir) {
      },
     devDependencies: {
         "electron-builder": "latest",
+        "proton-hot-cli": "latest",
         "babel-cli": "latest",
         "babel-preset-env": "latest",
         "babel-preset-stage-0": "latest",


### PR DESCRIPTION
Is `npm run dev` fine as the hot-reloading command?

The `Cannot read property 'setChild' of undefined` crash is fixed in proton-native 1.1.9.

<br>

- Added hot reloading to readme and fixed typos.
- Added all commands to the cli output:
```
Great! You are all set.
Created test-app inside /.../test-app


Inside that directory, you can run the following commands:

 npm run start
 Will run your application.

 npm run dev
 Will run your application with hot-reloading.

 npm run build
 Transpiles and bundles your source files.

 npm run dist
 Creates an archive containing the bundle.

Go to your project folder and run your application by typing:
 cd test-app
 npm run start
```