### PR TITLE
Upgrades use of Babel

### DIFF
--- a/src/createApp.js
+++ b/src/createApp.js
@@ -60,7 +60,6 @@ const createApp = function(projectDir) {
         "electron-builder": "latest",
         "babel-cli": "latest",
         "babel-preset-env": "latest",
-        "babel-preset-stage-0": "latest",
         "babel-preset-react": "latest"
     },
     build: {

--- a/src/createApp.js
+++ b/src/createApp.js
@@ -49,7 +49,7 @@ const createApp = function(projectDir) {
     private: true,
     scripts: {
       "start": "node_modules/.bin/babel-node index.js",
-      "build": "node_modules/.bin/babel index.js -d bin/",
+      "build": "node_modules/.bin/babel index.js --inspect bin/",
       "pack": "electron-builder --dir",
       "dist": "electron-builder"
     },
@@ -58,9 +58,11 @@ const createApp = function(projectDir) {
      },
     devDependencies: {
         "electron-builder": "latest",
-        "babel-cli": "latest",
-        "babel-preset-env": "latest",
-        "babel-preset-react": "latest"
+        "@babel/cli": "latest",
+        "@babel/core": "latest",
+        "@babel/node": "latest",
+        "@babel/preset-env": "latest",
+        "@babel/preset-react": "latest"
     },
     build: {
         "protonNodeVersion": "current",

--- a/template/.babelrc
+++ b/template/.babelrc
@@ -1,6 +1,6 @@
 {
     "presets": [
-      "env",
-      "react"
+      "@babel/env",
+      "@babel/react"
     ]
 }

--- a/template/.babelrc
+++ b/template/.babelrc
@@ -1,7 +1,6 @@
 {
     "presets": [
       "env",
-      "stage-0",
       "react"
     ]
 }


### PR DESCRIPTION
Even though the Babel packages were set to "latest" things have changed within their project that require package attention to use the newest features. This was tested on Windows 10 and Fedora 29.